### PR TITLE
Fix Package Depreciation Errors (Removed Zlib)

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "typescript": "^5.0.2"
   },
   "dependencies": {
-    "typed-emitter": "^2.1.0",
-    "zlib": "^1.0.5"
+    "typed-emitter": "^2.1.0"
   }
 }


### PR DESCRIPTION
Zlib was integrated into the node and is no longer available as a dependency. I did some testing and I didn't find any errors or any actual uses of that dependency. If I am mistaken please feel free to let me know.